### PR TITLE
Fixing typos in vim README

### DIFF
--- a/vim/README.md
+++ b/vim/README.md
@@ -1,104 +1,112 @@
 # VIM
-Vim is a 1991 editor for *NIX systems that is based on the 1976 vi editor. Vim is extremely lightweight and supports almost all modern languages. Vim is highly customizable and also has open source plugins available for various languages. Vim also allows you to automatically include banners and headers and license information in your files based on the file extension.
+
+Vim is a 1991 editor for \*NIX systems that is based on the 1976 vi editor. Vim is extremely lightweight and supports almost all modern languages. Vim is highly customizable and also has open source plugins available for various languages. Vim also allows you to automatically include banners and headers and license information in your files based on the file extension.
 
 ## Links
+
 - https://www.howtoforge.com/vim-basics
 - https://www.maketecheasier.com/vim-keyboard-shortcuts-cheatsheet/
 
 ## Installation
-$ sudo apt install -y vim
+
+\$ sudo apt install -y vim
 
 ## Vim modes
+
 - Command
-    - for operations like copy/paste, delete lines or words or characters, replace characters, navigate through source code (typically needs other tools like cscope and ctags)
+  - for operations like copy/paste, delete lines or words or characters, replace characters, navigate through source code (typically needs other tools like cscope and ctags)
 - Insert
-    - generally used for editing the files
+  - generally used for editing the files
 - Visual
-    - supports visually selecting, copying, deleting of areas in the file and so on
+  - supports visually selecting, copying, deleting of areas in the file and so on
 
 ## Vim shortcuts (Command Mode)
 
 - Copy an entire line
-    - "yy"
-    - "5yy" -> to yank the current and next four lines
+  - "yy"
+  - "5yy" -> to yank the current and next four lines
 - Paste (whatever has been copied)
-    - "p"
-    - "5p" -> paste whatever is copied 5 times
+  - "p"
+  - "5p" -> paste whatever is copied 5 times
 - Move
-    - "h" -> move right
-    - "l" -> move left
-    - "k" -> move up
-    - "j" -> move left
-    - "w" -> move to the start of the next word
-    - the arrow keys also work but these keystrokes are useful when moving a lot of positions
-        - for example, "10w" will move your cursor by 10 words.
-    - "^" -> move to the first non-blank character in the line
-    - "ctrl + d" -> half page down
-    - "ctrl + d" -> one page down
-    - "ctrl + u" -> half page up
-    - "ctrl + b" -> one page up
+  - "h" -> move right
+  - "l" -> move left
+  - "k" -> move up
+  - "j" -> move left
+  - "w" -> move to the start of the next word
+  - the arrow keys also work but these keystrokes are useful when moving a lot of positions
+    - for example, "10w" will move your cursor by 10 words.
+  - "^" -> move to the first non-blank character in the line
+  - "ctrl + d" -> half page down
+  - "ctrl + f" -> one page down
+  - "ctrl + u" -> half page up
+  - "ctrl + b" -> one page up
 - Append
-    - "a" -> after the current cursor location
+  - "a" -> after the current cursor location
 - Insert new blank line (this automatically puts you in insert mode)
-    - "o" -> below the current line
-    - "O" -> above the current line
+  - "o" -> below the current line
+  - "O" -> above the current line
 - Delete (this is actually "cut" - everthing removed is placed in the vim buffer and can be pasted from command mode with "p")
-    - "$d" -> remove everything from cursor position to end of line
-    - "d0" -> delete till beginning of line from current position
-    - "dd" -> remove the entire line
-    - "d" + "shift + g" -> remove everything from cursor position to end of file
-    - "d" + "gg" -> remove everything from cursor to beginning of file
+  - "\$d" -> remove everything from cursor position to end of line
+  - "d0" -> delete till beginning of line from current position
+  - "dd" -> remove the entire line
+  - "d" + "shift + g" -> remove everything from cursor position to end of file
+  - "d" + "gg" -> remove everything from cursor to beginning of file
 - Opening a new file
-    - ":edit `<`filename`>`"
+  - ":edit `<`filename`>`"
 - Saving a file
-    - ":w"
+  - ":w"
 - Closing a file
-    - "q" -> this fails if there are unsaved changes
-    - "q!" -> discard changes and close
-    - "wq!" -> save and close
+  - "q" -> this fails if there are unsaved changes
+  - "q!" -> discard changes and close
+  - "wq!" -> save and close
 - Undoing the last change
-    - "u" or ":u"
+  - "u" or ":u"
 - Go to line
-    - ":`<`line number`>`"
+  - ":`<`line number`>`"
 - Moving out of insert or visual mode
-    - Command mode is the default mode
-    - "esc" -> move out of a non-command mode
+  - Command mode is the default mode
+  - "esc" -> move out of a non-command mode
 - Go to beginning or end of file
-    - "shift + g" -> go to end of file
-    - "gg" -> go to beginning of file
+  - "shift + g" -> go to end of file
+  - "gg" -> go to beginning of file
 - Replace
-    - "r" -> replace a single character
-    - "R" -> goes to replace mode; every keystroke replaces the character under the cursor; press "esc" to go back to command mode
+  - "r" -> replace a single character
+  - "R" -> goes to replace mode; every keystroke replaces the character under the cursor; press "esc" to go back to command mode
 - Searching
-    - "/`<`pattern`>`" -> search for `<`pattern`>` below current position
-    - "?`<`pattern`>`" -> search for `<`pattern`>` above current position
-    - both operations wrap around
+  - "/`<`pattern`>`" -> search for `<`pattern`>` below current position
+  - "?`<`pattern`>`" -> search for `<`pattern`>` above current position
+  - both operations wrap around
 - Search and replace
-    - ":%s/`<`old`>`/`<`new`>`/g" -> search for all occurrences of `<`old`>` in file and replace with `<`new`>`
-    - ":%s/`<`old`>`/`<`new`>`/g" -> same as above but waits at all occurrences of `<`old`>` for confirmation to replace
+  - ":%s/`<`old`>`/`<`new`>`/g" -> search for all occurrences of `<`old`>` in file and replace with `<`new`>`
+  - ":%s/`<`old`>`/`<`new`>`/gc" -> same as above but waits at all occurrences of `<`old`>` for confirmation to replace
 - Buffer management
-    - ":ls" -> show all files open in vim
-        - ordered list
-    - ":b#" -> go to the previous file being edited
-    - ":b5" -> go to the file open in the 5th vim buffer
+  - ":ls" -> show all files open in vim
+    - ordered list
+  - ":b#" -> go to the previous file being edited
+  - ":b5" -> go to the file open in the 5th vim buffer
 
 ## Other modes
+
 - Visual mode
-    - Press "v" in command mode to get visual mode. Then you can move with arrow keys to select areas of text and then use the above shortcuts to yank or delete.
+  - Press "v" in command mode to get visual mode. Then you can move with arrow keys to select areas of text and then use the above shortcuts to yank or delete.
 - Insert mode
-    - Press "i" in command mode to get insert mode. You can type into your file in this mdoe.
+  - Press "i" in command mode to get insert mode. You can type into your file in this mdoe.
 
 ## Splitting vim panes
+
 - ":hsplit" -> split the panes horizontally
-    - ":hsplit `<filename`>" to open file in a new horizontally split pane
+  - ":hsplit `<filename`>" to open file in a new horizontally split pane
 - ":vsplit" -> split the panes vertically
 - If using NerdTree (a popular directory package), you can simply select the file and hit "s" to open it in a vertically split pane
 
 ## Setting up package manager for Vim
+
 https://github.com/VundleVim/Vundle.vim.git
 
 This is a popular Vim plugin manager; however, it is not the only one.
 Example vundle:
+
 ```
 Plugin 'VundleVim/Vundle.vim'
 Plugin 'c.vim'
@@ -108,8 +116,10 @@ call vundle#end()
 "c.vim" is a highly popular plugin for C that allows users to write C with Vim much more easily.
 
 ## Automatic templating with Vim
+
 Vim also supports the setting up automatic templates.
 Example for C files:
+
 ```
 if has("autocmd")
         augroup templates
@@ -118,6 +128,7 @@ if has("autocmd")
         augroup END
 endif
 ```
+
 - The first line adds the content of the skeleton.c file in ~/.vim/templates into the new C file.
 - The second line puts current date time into the file
 - If using "c.vim", then this is not required; Users can use ~/.vim/bundle/c.vim/c-support/templates/Templates file to set up templating.


### PR DESCRIPTION
## New programming tool?
Simply changing couple of typing mistakes in the Vim README:
1. "ctrl + d" -> one page down to "ctrl + f" -> one page down
2. ":%s/`<`old`>`/`<`new`>`/g" (interactive display) to ":%s/`<`old`>`/`<`new`>`/gc"

The rest I think are probably due to differences between our editors.

If you're providing a new programming tool, continue in this section.
Please check all of these (and do the implied work):

- [ ] I have included a subdirectory for the programming tool
- [ ] I have included a `README.md` in the directory with the information spelled out in the highest-level `README.md`
- [ ] I have written the `README.md` in a way that is approachable for beginners
- [ ] I have simplified the configuration files to be useable and approachable by beginners

## Changes to existing tool directories

- [ ] I have maintained the usability of the tool for beginners
- [ ] If you added a new configuration specific for another tool (e.g. `vim` bindings), you have added a new configuration with an appropriate name (e.g. `tmux_vim_config`)
- [x] I have tested to make sure that the configuration still works
